### PR TITLE
Closes #63: 1 change instead of 1 changes in pulls page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Vibinex Code Review",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "manifest_version": 3,
     "description": "Personalization and context for pull requests on GitHub & Bitbucket",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsRm6EaBdHDBxVjt9o9WKeL9EDdz1X+knDAU5uoZaRsXTmWjslhJN9DhSd7/Ys4aJOSN+s+5/HnIHcKV63P4GYaUM5FhETHEWORHlwIgjcV/1h6wD6bNbvXi06gtiygE+yMrCzzD93/Z+41XrwMElYiW2U5owNpat2Yfq4p9FDX1uBJUKsRIMp6LbRQla4vAzH/HMUtHWmeuUsmPVzcq1b6uB1QmuJqIQ1GrntIHw3UBWUlqRZ5OtxI1DCP3knglvqz26WT5Pc4GBDNlcI9+3F0vhwqwHqrdyjZpIKZ7iaQzcrovOqUKuXs1J3hDtXq8WoJELIqfIisY7rhAvq6b8jQIDAQAB",

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -238,7 +238,7 @@ function addingCssElementToGithub(elementId, status, changeInfo) {
 		// TODO: a better approach would be create a constant CSS for a class, and add the class to the elements in consideration
 		element.innerHTML = `#issue_${elementId}_link::before{
 		background-color:${tagBackgroundColor};
-		content: '${changeInfo['num_hunks_changed']} changes';
+		content: '${changeInfo['num_hunks_changed']} change${parseInt(changeInfo['num_hunks_changed']) == 1 ? '' : 's'}';
 		color: white;
 		width: 12px;
 		height: 12px;


### PR DESCRIPTION
Added a condition to check if there is only 1 change in the PR to make the 'change' noun singular as applicable.

(not tested on prod because APIs were not working)