### PR TITLE
storage change from sync to local

### DIFF
--- a/backgroundScript.js
+++ b/backgroundScript.js
@@ -3,10 +3,10 @@ chrome.runtime.onInstalled.addListener(() => {
 	// const environment = "dev";
 	const websiteUrl = (environment === "dev") ? "http://localhost:3000" : "https://vibinex.com";
 	const backendUrl = (environment === "dev") ? "http://localhost:8080" : "https://gcscruncsql-k7jns52mtq-el.a.run.app";
-	chrome.storage.sync.set({ websiteUrl, backendUrl }).then(_ => console.log(`Website URL set to ${websiteUrl};`));
+	chrome.storage.local.set({ websiteUrl, backendUrl }).then(_ => console.log(`Website URL set to ${websiteUrl};`));
 
 	// API call to backend that created Rudderstack event
-	chrome.storage.sync.get(["userId"]).then(({ userId }) => {
+	chrome.storage.local.get(["userId"]).then(({ userId }) => {
 		const body = {
 			userId: userId ? userId : "anonymous-id",
 			function: 'chrome-extension-installed'

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Vibinex Code Review",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "manifest_version": 3,
     "description": "Personalization and context for pull requests on GitHub & Bitbucket",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsRm6EaBdHDBxVjt9o9WKeL9EDdz1X+knDAU5uoZaRsXTmWjslhJN9DhSd7/Ys4aJOSN+s+5/HnIHcKV63P4GYaUM5FhETHEWORHlwIgjcV/1h6wD6bNbvXi06gtiygE+yMrCzzD93/Z+41XrwMElYiW2U5owNpat2Yfq4p9FDX1uBJUKsRIMp6LbRQla4vAzH/HMUtHWmeuUsmPVzcq1b6uB1QmuJqIQ1GrntIHw3UBWUlqRZ5OtxI1DCP3knglvqz26WT5Pc4GBDNlcI9+3F0vhwqwHqrdyjZpIKZ7iaQzcrovOqUKuXs1J3hDtXq8WoJELIqfIisY7rhAvq6b8jQIDAQAB",

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,4 @@
-chrome.storage.sync.get(["websiteUrl"]).then(({ websiteUrl }) => {
+chrome.storage.local.get(["websiteUrl"]).then(({ websiteUrl }) => {
 	fetch(`${websiteUrl}/api/auth/providers`, { cache: 'no-store' }).then(async (res) => {
 		const providers = await res.json();
 		const loginDiv = document.getElementById("login-div");
@@ -40,7 +40,7 @@ chrome.storage.sync.get(["websiteUrl"]).then(({ websiteUrl }) => {
 			document.querySelector("#session-name").innerHTML = user.name;
 			document.querySelector("#session-email").innerHTML = user.email;
 
-			chrome.storage.sync.set({
+			chrome.storage.local.set({
 				userId: user.id,
 				userName: user.name,
 				userImage: user.image

--- a/scripts/contentScript.js
+++ b/scripts/contentScript.js
@@ -141,7 +141,7 @@ async function sha256(value) {
 
 // for showing all tracked/ untrack pr in a organization
 async function getTrackedRepos(orgName, userId, repoHost) {
-	const { backendUrl } = await chrome.storage.sync.get(["backendUrl"]);
+	const { backendUrl } = await chrome.storage.local.get(["backendUrl"]);
 	let body = {};
 	let url = ''
 	switch (repoHost) {
@@ -566,7 +566,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 		console.warn(`[Vibinex] You are not logged in. Head to ${websiteUrl} to log in`);
 		// TODO: create a UI element on the screen with CTA to login to Vibinex
 	}
-	chrome.storage.sync.get(["backendUrl"]).then(async ({ backendUrl }) => {
+	chrome.storage.local.get(["backendUrl"]).then(async ({ backendUrl }) => {
 		if (urlObj[2] == 'github.com') {
 			if (urlObj[3] && (urlObj[3] !== 'orgs') && urlObj[4]) {
 				// for showing fav button if org repo is not added, eg : https://github.com/mui/mui-toolpad
@@ -670,7 +670,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 };
 
 window.onload = () => {
-	chrome.storage.sync.get(["websiteUrl", "userId"]).then(({ websiteUrl, userId }) => {
+	chrome.storage.local.get(["websiteUrl", "userId"]).then(({ websiteUrl, userId }) => {
 		console.log("We have the userId:", userId) // FIXME: remove this console.log
 		let oldHref = document.location.href;
 		orchestrator(oldHref, websiteUrl, userId);


### PR DESCRIPTION
According to [the documentation](https://developer.chrome.com/docs/extensions/reference/storage/#storage-areas), `chrome.storage.sync` should have behaved exactly like `chrome.storage.local` when sync is disabled.

But with one of the users, we observed otherwise. We saw that the extension was not working unless sync was enabled.

Since in our case, there isn't any real advantage to using `sync`, it is better that we use the more robust type of storage.