### PR TITLE
Fixes #68 and fixing Vibinex logo appearing beside Fork Urls in repositories list

### DIFF
--- a/scripts/orchestrator.js
+++ b/scripts/orchestrator.js
@@ -21,7 +21,9 @@
 const orchestrator = (tabUrl, websiteUrl, userId) => {
 	console.debug(`[vibinex-orchestrator] updated url: ${tabUrl}`);
 	const urlObj = tabUrl.split('?')[0].split('/');
-	const urlEnd = tabUrl.split('?')[1]
+	const urlEnd = tabUrl.split('?')[1];
+	// for a possible case like https://github.com/AJAYK-01?tab=repositories&success=true
+	const urlFirstParam = urlEnd !== undefined ? urlEnd.split('&')[0] : undefined;
 	if (!userId && (urlObj[2] === 'github.com' || urlObj[2] === 'bitbucket.org')) {
 		console.warn(`[Vibinex] You are not logged in. Head to ${websiteUrl} to log in`);
 		// TODO: create a UI element on the screen with CTA to login to Vibinex
@@ -73,7 +75,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 			}
 			// for showing all tracked repo in organisation page
 			else if (
-				(urlObj[3] && urlObj[4] == undefined && urlEnd !== 'tab=repositories') ||
+				(urlObj[3] && urlObj[4] == undefined && urlFirstParam !== 'tab=repositories') ||
 				(urlObj[3] == 'orgs' && urlObj[4] && urlObj[5] === 'repositories')) {
 				// for woking on this url https://github.com/Alokit-Innovations or https://github.com/orgs/Alokit-Innovations/repositories?type=all type 
 				const orgName = (urlObj[3] === "orgs") ? urlObj[4] : urlObj[3];
@@ -81,7 +83,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 				updateTrackedReposInGitHub(trackedRepos, websiteUrl, 'org');
 			}
 			// for showing all tracked repo in user page
-			else if (urlObj[3] && !urlObj[4] && urlEnd === 'tab=repositories') {
+			else if (urlObj[3] && !urlObj[4] && urlFirstParam === 'tab=repositories') {
 				// for working on this url https://github.com/username?tab=repositories
 				const userName = urlObj[3]
 				const trackedRepos = await getTrackedRepos(userName, userId, 'github');

--- a/scripts/orchestrator.js
+++ b/scripts/orchestrator.js
@@ -23,7 +23,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 	const urlObj = tabUrl.split('?')[0].split('/');
 	const urlEnd = tabUrl.split('?')[1];
 	// for a possible case like https://github.com/AJAYK-01?tab=repositories&success=true
-	const urlFirstParam = urlEnd !== undefined ? urlEnd.split('&')[0] : undefined;
+	const searchParams = urlEnd !== undefined ? urlEnd.split('&') : [];
 	if (!userId && (urlObj[2] === 'github.com' || urlObj[2] === 'bitbucket.org')) {
 		console.warn(`[Vibinex] You are not logged in. Head to ${websiteUrl} to log in`);
 		// TODO: create a UI element on the screen with CTA to login to Vibinex
@@ -75,7 +75,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 			}
 			// for showing all tracked repo in organisation page
 			else if (
-				(urlObj[3] && urlObj[4] == undefined && urlFirstParam !== 'tab=repositories') ||
+				(urlObj[3] && urlObj[4] == undefined && !searchParams.includes('tab=repositories')) ||
 				(urlObj[3] == 'orgs' && urlObj[4] && urlObj[5] === 'repositories')) {
 				// for woking on this url https://github.com/Alokit-Innovations or https://github.com/orgs/Alokit-Innovations/repositories?type=all type 
 				const orgName = (urlObj[3] === "orgs") ? urlObj[4] : urlObj[3];
@@ -83,7 +83,7 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 				updateTrackedReposInGitHub(trackedRepos, websiteUrl, 'org');
 			}
 			// for showing all tracked repo in user page
-			else if (urlObj[3] && !urlObj[4] && urlFirstParam === 'tab=repositories') {
+			else if (urlObj[3] && !urlObj[4] && searchParams.includes('tab=repositories')) {
 				// for working on this url https://github.com/username?tab=repositories
 				const userName = urlObj[3]
 				const trackedRepos = await getTrackedRepos(userName, userId, 'github');

--- a/scripts/orchestrator.js
+++ b/scripts/orchestrator.js
@@ -71,20 +71,21 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 					githubHunkHighlight(hunk_info_response);
 				}
 			}
-			else if (urlEnd === 'tab=repositories') {
-				// for working on this url https://github.com/username?tab=repositories
-				const userName = urlObj[3]
-				const trackedRepos = await getTrackedRepos(userName, userId, 'github');
-				updateTrackedReposInUserGitHub(trackedRepos, websiteUrl)
-			}
-			// for showing all tracked repo
+			// for showing all tracked repo in organisation page
 			else if (
-				(urlObj[3] && urlObj[4] == undefined) ||
+				(urlObj[3] && urlObj[4] == undefined && urlEnd !== 'tab=repositories') ||
 				(urlObj[3] == 'orgs' && urlObj[4] && urlObj[5] === 'repositories')) {
 				// for woking on this url https://github.com/Alokit-Innovations or https://github.com/orgs/Alokit-Innovations/repositories?type=all type 
 				const orgName = (urlObj[3] === "orgs") ? urlObj[4] : urlObj[3];
 				const trackedRepos = await getTrackedRepos(orgName, userId, 'github');
-				updateTrackedReposInOrgGitHub(trackedRepos, websiteUrl);
+				updateTrackedReposInGitHub(trackedRepos, websiteUrl, 'org');
+			}
+			// for showing all tracked repo in user page
+			else if (urlObj[3] && !urlObj[4] && urlEnd === 'tab=repositories') {
+				// for working on this url https://github.com/username?tab=repositories
+				const userName = urlObj[3]
+				const trackedRepos = await getTrackedRepos(userName, userId, 'github');
+				updateTrackedReposInGitHub(trackedRepos, websiteUrl, 'user')
 			}
 		}
 

--- a/scripts/orchestrator.js
+++ b/scripts/orchestrator.js
@@ -21,6 +21,7 @@
 const orchestrator = (tabUrl, websiteUrl, userId) => {
 	console.debug(`[vibinex-orchestrator] updated url: ${tabUrl}`);
 	const urlObj = tabUrl.split('?')[0].split('/');
+	const urlEnd = tabUrl.split('?')[1]
 	if (!userId && (urlObj[2] === 'github.com' || urlObj[2] === 'bitbucket.org')) {
 		console.warn(`[Vibinex] You are not logged in. Head to ${websiteUrl} to log in`);
 		// TODO: create a UI element on the screen with CTA to login to Vibinex
@@ -69,6 +70,12 @@ const orchestrator = (tabUrl, websiteUrl, userId) => {
 					const hunk_info_response = await apiCall(hunk_info_url, hunk_info_body);
 					githubHunkHighlight(hunk_info_response);
 				}
+			}
+			else if (urlEnd === 'tab=repositories') {
+				// for working on this url https://github.com/username?tab=repositories
+				const userName = urlObj[3]
+				const trackedRepos = await getTrackedRepos(userName, userId, 'github');
+				updateTrackedReposInUserGitHub(trackedRepos, websiteUrl)
 			}
 			// for showing all tracked repo
 			else if (

--- a/scripts/repoHandlers.js
+++ b/scripts/repoHandlers.js
@@ -107,6 +107,48 @@ function updateTrackedReposInOrgGitHub(trackedRepos, websiteUrl) {
 }
 
 /**
+ * Updates the user's GitHub repositories page to visually indicate which repositories are being tracked.
+ * 
+ * @param {Array} trackedRepos - List of tracked repositories.
+ * @param {string} websiteUrl - The URL of the website.
+ */
+function updateTrackedReposInUserGitHub(trackedRepos, websiteUrl) {
+	const allUserRepo = document.getElementById('user-repositories-list');
+	const userRepoUrl = Array.from(allUserRepo.getElementsByTagName('a'));
+
+	userRepoUrl.forEach((item) => {
+		const link = item.getAttribute('href').split('/');
+		const userRepoName = link[link.length - 1];
+
+		if (trackedRepos.includes(userRepoName)) {
+			const checkElement = item.getElementsByClassName('trackLogo')[0];
+			if (checkElement) {
+				// TODO: Ideally, we should only need to add the element when there is none present
+				checkElement.remove();
+			}
+			const img = document.createElement("img");
+			img.setAttribute('class', 'trackLogo');
+			const beforePsuedoElement = document.createElement('a');
+			img.src = `${websiteUrl}/favicon.ico`;
+			img.style.width = '15px'
+			img.style.height = '15px'
+
+			beforePsuedoElement.appendChild(img);
+			beforePsuedoElement.href = `${websiteUrl}/repo?repo_name=${userRepoName}`;
+			beforePsuedoElement.target = '_blank';
+			beforePsuedoElement.style.display = 'inline-block';
+			beforePsuedoElement.style.marginRight = '2px';
+			beforePsuedoElement.style.color = 'white';
+			beforePsuedoElement.style.borderRadius = '2px';
+			beforePsuedoElement.style.fontSize = '15px';
+			beforePsuedoElement.style.textDecoration = 'none';
+
+			item.insertBefore(beforePsuedoElement, item.firstChild);
+		}
+	})
+}
+
+/**
  * Displays a floating action button on the repository page if the repository is not being tracked.
  * 
  * @param {string} orgName - The name of the organization or user.

--- a/scripts/repoHandlers.js
+++ b/scripts/repoHandlers.js
@@ -72,7 +72,7 @@ function updateTrackedReposInBitbucketOrg(trackedRepos, websiteUrl) {
  */
 function updateTrackedReposInOrgGitHub(trackedRepos, websiteUrl) {
 	const allOrgRepo = document.getElementById('org-repositories');
-	const orgRepoUrl = Array.from(allOrgRepo.getElementsByTagName('a'));
+	const orgRepoUrl = Array.from(allOrgRepo.querySelectorAll('a[itemprop="name codeRepository"]'));
 
 	orgRepoUrl.forEach((item) => {
 		const link = item.getAttribute('href').split('/');
@@ -114,7 +114,7 @@ function updateTrackedReposInOrgGitHub(trackedRepos, websiteUrl) {
  */
 function updateTrackedReposInUserGitHub(trackedRepos, websiteUrl) {
 	const allUserRepo = document.getElementById('user-repositories-list');
-	const userRepoUrl = Array.from(allUserRepo.getElementsByTagName('a'));
+	const userRepoUrl = Array.from(allUserRepo.querySelectorAll('a[itemprop="name codeRepository"]'));
 
 	userRepoUrl.forEach((item) => {
 		const link = item.getAttribute('href').split('/');

--- a/scripts/repoHandlers.js
+++ b/scripts/repoHandlers.js
@@ -65,20 +65,22 @@ function updateTrackedReposInBitbucketOrg(trackedRepos, websiteUrl) {
 }
 
 /**
- * Updates the GitHub organization page to visually indicate which repositories are being tracked.
+ * Updates the GitHub organization or user page to visually indicate which repositories are being tracked.
  * 
  * @param {Array} trackedRepos - List of tracked repositories.
  * @param {string} websiteUrl - The URL of the website.
+ * @param {boolean} isOrg - Whether github organization or user.
  */
-function updateTrackedReposInOrgGitHub(trackedRepos, websiteUrl) {
-	const allOrgRepo = document.getElementById('org-repositories');
-	const orgRepoUrl = Array.from(allOrgRepo.querySelectorAll('a[itemprop="name codeRepository"]'));
+function updateTrackedReposInGitHub(trackedRepos, websiteUrl, ownerType) {
+	const allRepo = ownerType == 'org' ? document.getElementById('org-repositories') : document.getElementById('user-repositories-list');
+	const repoUrl = Array.from(allRepo.querySelectorAll('a[itemprop="name codeRepository"]'));
 
-	orgRepoUrl.forEach((item) => {
+
+	repoUrl.forEach((item) => {
 		const link = item.getAttribute('href').split('/');
-		const orgRepoName = link[link.length - 1];
+		const repoName = link[link.length - 1];
 
-		if (trackedRepos.includes(orgRepoName)) {
+		if (trackedRepos.includes(repoName)) {
 			const checkElement = item.getElementsByClassName('trackLogo')[0];
 			if (checkElement) {
 				// TODO: Ideally, we should only need to add the element when there is none present
@@ -92,49 +94,7 @@ function updateTrackedReposInOrgGitHub(trackedRepos, websiteUrl) {
 			img.style.height = '15px'
 
 			beforePsuedoElement.appendChild(img);
-			beforePsuedoElement.href = `${websiteUrl}/repo?repo_name=${orgRepoName}`;
-			beforePsuedoElement.target = '_blank';
-			beforePsuedoElement.style.display = 'inline-block';
-			beforePsuedoElement.style.marginRight = '2px';
-			beforePsuedoElement.style.color = 'white';
-			beforePsuedoElement.style.borderRadius = '2px';
-			beforePsuedoElement.style.fontSize = '15px';
-			beforePsuedoElement.style.textDecoration = 'none';
-
-			item.insertBefore(beforePsuedoElement, item.firstChild);
-		}
-	})
-}
-
-/**
- * Updates the user's GitHub repositories page to visually indicate which repositories are being tracked.
- * 
- * @param {Array} trackedRepos - List of tracked repositories.
- * @param {string} websiteUrl - The URL of the website.
- */
-function updateTrackedReposInUserGitHub(trackedRepos, websiteUrl) {
-	const allUserRepo = document.getElementById('user-repositories-list');
-	const userRepoUrl = Array.from(allUserRepo.querySelectorAll('a[itemprop="name codeRepository"]'));
-
-	userRepoUrl.forEach((item) => {
-		const link = item.getAttribute('href').split('/');
-		const userRepoName = link[link.length - 1];
-
-		if (trackedRepos.includes(userRepoName)) {
-			const checkElement = item.getElementsByClassName('trackLogo')[0];
-			if (checkElement) {
-				// TODO: Ideally, we should only need to add the element when there is none present
-				checkElement.remove();
-			}
-			const img = document.createElement("img");
-			img.setAttribute('class', 'trackLogo');
-			const beforePsuedoElement = document.createElement('a');
-			img.src = `${websiteUrl}/favicon.ico`;
-			img.style.width = '15px'
-			img.style.height = '15px'
-
-			beforePsuedoElement.appendChild(img);
-			beforePsuedoElement.href = `${websiteUrl}/repo?repo_name=${userRepoName}`;
+			beforePsuedoElement.href = `${websiteUrl}/repo?repo_name=${repoName}`;
 			beforePsuedoElement.target = '_blank';
 			beforePsuedoElement.style.display = 'inline-block';
 			beforePsuedoElement.style.marginRight = '2px';


### PR DESCRIPTION
Fixes #68 

### The other issue addressed:
The Forked url was also being recognized by the extension if it has the same repo name, and the logo was being added.
Fixed that too by only selecting the a href element with ```itemprop="name codeRepository"``` to indicate main repo urls.

![IMAGE 2023-11-06 22:31:05](https://github.com/Alokit-Innovations/chrome-extension/assets/55079486/6fad78bf-4e58-43aa-afe6-a7a8a1788734)


### After Fix:
<img width="652" alt="Screenshot 2023-11-06 at 10 21 35 PM" src="https://github.com/Alokit-Innovations/chrome-extension/assets/55079486/37d86f1c-2030-46b2-8862-93063d095557">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the orchestrator to handle retrieval and updating of tracked repositories on GitHub for both user and organization pages.
  - Introduced a visual indicator on the GitHub repositories page to show which repositories are being tracked.

- **Refactor**
  - Generalized functions to work with both organization and user repository pages on GitHub.
  - Updated function parameters and logic to accommodate new tracking features.

- **Style**
  - Minor formatting improvements for better readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->