### PR TITLE
Fix unknown margin on bitbucket.org vibinex logo in #86

### DIFF
--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -45,6 +45,7 @@ function createElement(type = "add", websiteUrl = "https://vibinex.com") {
 	img.style.width = '35px';
 	img.style.height = '35px';
 	img.style.borderRadius = '35px';
+	img.style.margin = '0px';
 	img.style.position = 'fixed';
 	img.style.left = '30px';
 	img.style.bottom = '50px';


### PR DESCRIPTION
### Problem

- An unknown margin was being added to the vibinex logo in the sign in indicator (that was added in #86) on [bitbucket.org](https://bitbucket.org)

![blob](https://github.com/Alokit-Innovations/chrome-extension/assets/55079486/888d03bf-d97b-467e-a888-fc7ca352d622)

### Fix

- By overriding the value of margin for the vibinex logo element manually, the issue has been fixed.
- The fix has no adverse effects on other sites which didn't have the bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual layout of images by setting their margin to 0px for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->