### PR TITLE
Bitbucket hunk highlighting bugfix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Vibinex Code Review",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "manifest_version": 3,
     "description": "Personalization and context for pull requests on GitHub & Bitbucket",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsRm6EaBdHDBxVjt9o9WKeL9EDdz1X+knDAU5uoZaRsXTmWjslhJN9DhSd7/Ys4aJOSN+s+5/HnIHcKV63P4GYaUM5FhETHEWORHlwIgjcV/1h6wD6bNbvXi06gtiygE+yMrCzzD93/Z+41XrwMElYiW2U5owNpat2Yfq4p9FDX1uBJUKsRIMp6LbRQla4vAzH/HMUtHWmeuUsmPVzcq1b6uB1QmuJqIQ1GrntIHw3UBWUlqRZ5OtxI1DCP3knglvqz26WT5Pc4GBDNlcI9+3F0vhwqwHqrdyjZpIKZ7iaQzcrovOqUKuXs1J3hDtXq8WoJELIqfIisY7rhAvq6b8jQIDAQAB",

--- a/scripts/highlighting.js
+++ b/scripts/highlighting.js
@@ -294,7 +294,7 @@ const bitBucketHunkHighlight = (apiResponses) => {
 					const articles = document.querySelectorAll('article[aria-label^="Diff of file"]');
 					articles.forEach(async (article) => {
 						const ariaLabel = article.getAttribute('aria-label');
-						const fileName = ariaLabel.substring(13); // beacuse ariaLable = "Diff of file testFile.js", so removing first 13 letters to get the file name
+						const fileName = ariaLabel.substring(13); // because ariaLable = "Diff of file testFile.js", so removing first 13 letters to get the file name
 
 						const matchEncrypted = await sha256(fileName);
 						const foundFiles = apiResponses["hunkinfo"].find(item => item.filepath === matchEncrypted);

--- a/scripts/highlighting.js
+++ b/scripts/highlighting.js
@@ -334,7 +334,7 @@ const bitBucketHunkHighlight = (apiResponses) => {
 											if (lineNumber >= lineStart && lineNumber <= lineEnd) {
 												const firstElement = item.firstElementChild;
 												const secondChild = firstElement.children[2];
-												secondChild.style.borderLeft = 'solid 6px #f1f549';
+												secondChild.style.borderLeft = 'solid 6px #eaee32';
 											}
 										} else if (symbol == '+') {
 											const lineNumber = getLineNumber(item);
@@ -356,10 +356,10 @@ const bitBucketHunkHighlight = (apiResponses) => {
 
 									if (symbol == '-' || symbol == '+') {
 										const lineNumber = getLineNumber(item);
-										if (lineNumber >= lineStart && lineNumber <= lineEnd) {
+										if (lineNumber >= lineStart && lineNumber <= lineEnd && symbol == '-') {
 											const firstElement = item.firstElementChild;
 											const secondChild = firstElement.children[2];
-											secondChild.style.borderLeft = 'solid 6px #f1f549';
+											secondChild.style.borderLeft = 'solid 6px #eaee32';
 										}
 									}
 								});

--- a/scripts/highlighting.js
+++ b/scripts/highlighting.js
@@ -309,7 +309,7 @@ const bitBucketHunkHighlight = (apiResponses) => {
 							const statusDetail = status.classList;
 
 							const listOfChunks = article.getElementsByClassName('diff-chunk-inner');
-							const allChunkLines = listOfChunks[0].querySelectorAll('.lines-wrapper');
+							const allChunkLines = Array.from(listOfChunks).map(chunk => Array.from(chunk.querySelectorAll('.lines-wrapper')));
 
 							const lineStart = parseInt(foundFiles.line_start);
 							const lineEnd = parseInt(foundFiles.line_end);


### PR DESCRIPTION
**Bug**: Lines were only getting highlighted if they were in the first "chunk" within all the changes in a file of the pull request.

**Fix**: Instead of only processing lines in the first chunk of each file, we iterate over all the chunks of each file.

Other improvements in this pull request:
- Changed the color of the line highlighting (in light theme, the highlight color was not visible next to the subtle red highlight of the deleted lines
- Made the line highlighting for relevant deletions more specific to only code deletions - but only for the unified view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the color scheme for code difference highlighting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->